### PR TITLE
feat(timeline): Prevent editing of past timeline items

### DIFF
--- a/src/components/timelineGantt/components/ItemDialog/index.jsx
+++ b/src/components/timelineGantt/components/ItemDialog/index.jsx
@@ -21,6 +21,7 @@ import { canTransitTo, MACHINE_STATUS } from "../../configs/constants";
 import StatusController from "../StatusForms/StatusForms";
 import StatusChangeDialog from "./StatusChangeDialog";
 import { handleFormError, StatusError } from "../../utils/errorHandler";
+import dayjs from "dayjs";
 
 //! =============== 2. 類型與介面 ===============
 //* 組件屬性定義
@@ -165,12 +166,20 @@ const ItemDialog = ({
           <StatusController
             status={currentStatus}
             item={item}
-            disabled={mode === "view" || isSubmitting}
+            // disabled={mode === "view" || isSubmitting}
             onSubmit={handleSubmit}
             mode={mode}
             isSubmitting={isSubmitting}
             onClose={onClose}
             groups={groups}
+            // 過去的項目不允許修改 , add 模式自由
+            disabled={
+              mode === "view" ||
+              isSubmitting ||
+              (mode !== "add" &&
+                (item.start < dayjs() ||
+                  item.orderInfo.scheduledStartTime < dayjs()))
+            }
           />
         </DialogContent>
       </Dialog>

--- a/src/components/timelineGantt/configs/orderItems.js
+++ b/src/components/timelineGantt/configs/orderItems.js
@@ -68,6 +68,27 @@ export const generateInitialOrders = () => {
           ? item.orderInfo.actualEndTime || item.orderInfo.scheduledEndTime
           : item.status.endTime || dayjs(item.status.startTime).add(2, "hour")
       ).toDate(),
+      editable:
+        item.timeLineStatus === MACHINE_STATUS.ORDER_CREATED
+          ? {
+              //  檢查是否為過去的項目
+              updateTime:
+                item.orderInfo.actualStartTime ||
+                item.orderInfo.scheduledStartTime < dayjs()
+                  ? false
+                  : true,
+              updateGroup:
+                item.orderInfo.actualStartTime ||
+                item.orderInfo.scheduledStartTime < dayjs()
+                  ? false
+                  : true,
+              remove: false,
+            }
+          : {
+              updateTime: false,
+              updateGroup: false,
+              remove: true,
+            },
     }))
   );
 };


### PR DESCRIPTION
- Added time-based editing restrictions in ItemDialog
- Updated order item generation to include editable flags based on item status and time
- Disabled status modifications for items with past scheduled or actual start times