### PR TITLE
fix: 更新 Vite 配置與路由設定以統一 base 路徑

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -75,7 +75,7 @@ const router = createBrowserRouter(
     },
   ],
   {
-    // basename: "",
+    basename: "/React-WiseScheduling_TimeLine_Library/",
   }
 );
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,8 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig(({ command }) => {
-    const base =
-        command === "build" ? "/React-WiseScheduling_TimeLine_Library/" : "/";
+    const base = "/React-WiseScheduling_TimeLine_Library/";
 
     return {
         base,


### PR DESCRIPTION
- 將 Vite 配置中的 base 路徑固定為 GitHub Pages 倉庫路徑
- 更新 App.jsx 中的 basename 設定，確保路由正確指向相同的路徑