### PR TITLE
fix: 將路由配置從 BrowserRouter 更新為 HashRouter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { createHashRouter, RouterProvider } from "react-router-dom";
 import { lazy, Suspense } from "react";
 import AppLayout from "./layouts/AppLayout";
 import FullScreenLayout from "./layouts/FullScreenLayout";
@@ -22,62 +22,56 @@ const ManufacturingLiveMonitor = lazy(
     )
 );
 
-// 創建路由配置
-const router = createBrowserRouter(
-  [
-    {
-      path: "/",
-      element: <AppLayout />,
-      errorElement: <ErrorPage />,
-      children: [
-        { index: true, element: <Home /> },
-        { path: "timeline", element: <Timeline /> },
-        { path: "about", element: <About /> },
-        { path: "contact", element: <Contact /> },
-        {
-          path: "dynamic-timeline",
-          element: (
-            <Suspense fallback={<LoadingSpinner text="載入動態時間軸中..." />}>
-              <DynamicTimeline />
-            </Suspense>
-          ),
-        },
-        {
-          path: "query-example",
-          element: (
-            <Suspense fallback={<LoadingSpinner text="載入查詢範例中..." />}>
-              <QueryExample />
-            </Suspense>
-          ),
-        },
-        // 已移除全屏頁面到獨立路由
-        // 捕捉所有不匹配的路徑
-        { path: "*", element: <ErrorPage /> },
-      ],
-    },
-    {
-      // 全屏頁面使用隔離布局
-      path: "ManufacturingLiveMonitor",
-      element: <FullScreenLayout />,
-      children: [
-        {
-          // 預設路由
-          index: true,
-          element: (
-            //  使用 await 加上 setTimeout 來模擬載入時間
-            <Suspense fallback={<Loading>載入製造現場即時監控中...</Loading>}>
-              <ManufacturingLiveMonitor />
-            </Suspense>
-          ),
-        },
-        // 未來可能的其他全屏頁面可在此添加
-      ],
-    },
-  ],
+// 使用 HashRouter 代替 BrowserRouter
+const router = createHashRouter([
   {
-    basename: "/React-WiseScheduling_TimeLine_Library/",
-  }
-);
+    path: "/",
+    element: <AppLayout />,
+    errorElement: <ErrorPage />,
+    children: [
+      { index: true, element: <Home /> },
+      { path: "timeline", element: <Timeline /> },
+      { path: "about", element: <About /> },
+      { path: "contact", element: <Contact /> },
+      {
+        path: "dynamic-timeline",
+        element: (
+          <Suspense fallback={<LoadingSpinner text="載入動態時間軸中..." />}>
+            <DynamicTimeline />
+          </Suspense>
+        ),
+      },
+      {
+        path: "query-example",
+        element: (
+          <Suspense fallback={<LoadingSpinner text="載入查詢範例中..." />}>
+            <QueryExample />
+          </Suspense>
+        ),
+      },
+      // 捕捉所有不匹配的路徑
+      { path: "*", element: <ErrorPage /> },
+    ],
+  },
+  {
+    // 全屏頁面使用隔離布局
+    path: "/ManufacturingLiveMonitor",
+    element: <FullScreenLayout />,
+    children: [
+      {
+        // 預設路由
+        index: true,
+        element: (
+          //  使用 await 加上 setTimeout 來模擬載入時間
+          <Suspense fallback={<Loading>載入製造現場即時監控中...</Loading>}>
+            <ManufacturingLiveMonitor />
+          </Suspense>
+        ),
+      },
+      // 未來可能的其他全屏頁面可在此添加
+    ],
+  },
+]);
 
 function App() {
   return <RouterProvider router={router} />;


### PR DESCRIPTION
- 使用 HashRouter 代替 BrowserRouter，以改善在 GitHub Pages 上的路由行為
- 調整 ManufacturingLiveMonitor 路由的 path 設定，確保正確指向全屏頁面